### PR TITLE
fix: address MoneyMoney signing review feedback

### DIFF
--- a/EquatePlus.lua
+++ b/EquatePlus.lua
@@ -5,6 +5,15 @@ function rnd()
   return math.random(10000000,99999999)
 end
 
+local function urlencode(s)
+  if s == nil then return "" end
+  s = tostring(s)
+  s = string.gsub(s, "([^A-Za-z0-9%-_%.~])", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end)
+  return s
+end
+
 local baseurl=""
 local dcHost = "https://www.equateplus.com"
 local reportOnce
@@ -78,7 +87,7 @@ function connectWithCSRF(method, url, postContent, postContentType, headers)
     end
     h["Accept"] = h["Accept"] or "*/*"
     -- For login orchestration endpoints, request JSON and mark XHR
-    if string.find(u, "?login") then
+    if string.find(u, "%?login") then
       h["Accept"] = "application/json, text/plain, */*"
       h["X-Requested-With"] = h["X-Requested-With"] or "XMLHttpRequest"
       if h["Referer"] == nil then
@@ -99,7 +108,7 @@ function connectWithCSRF(method, url, postContent, postContentType, headers)
     if headers == nil then headers={} end
     headers["Accept"] = headers["Accept"] or "*/*"
     -- For login orchestration endpoints, request JSON and mark XHR
-    if string.find(url, "?login") then
+    if string.find(url, "%?login") then
       headers["Accept"] = "application/json, text/plain, */*"
       headers["X-Requested-With"] = headers["X-Requested-With"] or "XMLHttpRequest"
       if headers["Referer"] == nil then
@@ -212,8 +221,8 @@ function InitializeSession2 (protocol, bankCode, step, credentials, interactive)
     CSRF2_TOKEN=nil
     connection = Connection()
 
-    username=credentials[1]
-    password=credentials[2]
+    local username=credentials[1]
+    local password=credentials[2]
 
     if string.sub(username,1,1) == '#' then
       print("Debugging, remove # char from username!")
@@ -243,8 +252,7 @@ function InitializeSession2 (protocol, bankCode, step, credentials, interactive)
       -- Outage screen or changed landing; attempt geo DCs
       local tried = {
         "https://www.emea.equateplus.com/EquatePlusParticipant2/?login",
-        "https://www.na.equateplus.com/EquatePlusParticipant2/?login",
-        "https://participant.tst.equateplus.com/EquatePlusParticipant2/?login" -- BT1 fallback (rare)
+        "https://www.na.equateplus.com/EquatePlusParticipant2/?login"
       }
       for _, u in ipairs(tried) do
         -- Pin host to the candidate datacenter
@@ -330,7 +338,7 @@ function InitializeSession2 (protocol, bankCode, step, credentials, interactive)
     local resp = connectWithCSRF(
       "POST",
       "https://www.equateplus.com/EquatePlusParticipant2/?login&_cId="..cId.."&_rId="..rnd(),
-      "isiwebuserid="..username.."&isiwebpasswd=null&result=null",
+      "isiwebuserid="..urlencode(username).."&isiwebpasswd=null&result=null",
       "application/x-www-form-urlencoded"
     )
     local ok, json = pcall(function() return JSON(resp):dictionary() end)
@@ -398,7 +406,7 @@ function InitializeSession2 (protocol, bankCode, step, credentials, interactive)
     -- Wait up to 30 seconds for verification (FIDO/QR)
     local count = 0
     while count < 30 do
-      json = JSON(connectWithCSRF("GET","https://www.equateplus.com/EquatePlusParticipant2/?login&o.fidoUafSessionId.v="..session_id.."&_cId="..cId.."&_rId="..rnd())):dictionary()
+      local json = JSON(connectWithCSRF("GET","https://www.equateplus.com/EquatePlusParticipant2/?login&o.fidoUafSessionId.v="..session_id.."&_cId="..cId.."&_rId="..rnd())):dictionary()
       print(json["status"])
       if json["status"] == "succeeded" then
         -- Complete login after verification

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # EquatePlus Extension for MoneyMoney
 
-A MoneyMoney extension for tracking EquatePlus employee share plan portfolios and downloading account statements.
-
-> **Based on the original work by [neatc0der](https://github.com/neatc0der/equateplus-moneymoney).
-> This fork adds SMS OTP authentication support and several robustness improvements.**
+A MoneyMoney extension for tracking EquatePlus employee share plan portfolios and downloading account statements. Supports both the EquateAccess App (QR/FIDO) and SMS one-time-code authentication.
 
 ---
 
@@ -12,7 +9,7 @@ A MoneyMoney extension for tracking EquatePlus employee share plan portfolios an
 - Portfolio synchronisation (positions, quantities, purchase prices, market prices)
 - Statement download from the EquatePlus document library
 - **EquateAccess App** (FIDO/QR code) authentication
-- **SMS security code (OTP)** authentication — added in this fork
+- **SMS security code (OTP)** authentication
 - Datacenter failover with host pinning (EMEA / NA / primary)
 - Robust login detection across datacenter variants
 - Cumulative position mode (aggregate positions per security)


### PR DESCRIPTION
## Why another PR

The MoneyMoney signing team reviewed the extension after PR #9 was merged and sent back a short list of security-critical findings that need to be fixed before they will sign the extension for the official download page. This PR addresses every item from that review so the extension can be signed and listed.

## Changes

### `EquatePlus.lua`

| # | Issue from the signing review | Fix |
|---|---|---|
| 1 | `username` / `password` were implicit globals in `InitializeSession2` step 1 | Added `local` |
| 2 | `string.find(url, "?login")` — `?` is a Lua-pattern quantifier, not a literal | Changed to `"%?login"` (2 sites in `connectWithCSRF`) |
| 3 | `username` was concatenated into the login POST body without URL-encoding | Added a small `urlencode()` helper and applied it to `username` in the `isiwebuserid=...` body |
| 4 | `json` was an implicit global in the FIDO/QR polling loop in step 2 | Added `local` |
| 5 | The `participant.tst.equateplus.com` fallback URL is not reachable and triggers daily MoneyMoney whitelist errors | Removed; EMEA + NA fallbacks remain |

### `README.md`

Reworked the intro so it no longer reads as a downstream fork now that this code lives on upstream master. The Credits section at the bottom (original extension + SMS-OTP/robustness contribution attribution) is unchanged.

## Verification

- Tested locally against a live EquatePlus account (SMS-OTP flow), positions and statements sync as expected.
- No bankCode or `services={...}` change — existing MoneyMoney accounts and history are preserved.

## Background

For context: I was in contact with the MoneyMoney support team before PR #9 was merged. They had agreed in principle to sign a renamed variant of the extension if upstream stayed inactive. With PR #9 now merged, the cleaner path for everyone is to land these signing-review fixes upstream and have a single signed `EquatePlus.lua` on the official download page instead of two near-identical extensions.